### PR TITLE
Change full name to name, remove unused/unnecessary HTML classes/selectors 

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,28 +15,26 @@
     <header></header>
 
     <main>
-        <section class="shadow-spacing">
-            <section class="form-wrapper">
-                <h2>Contact Us</h2>
-                <form name="contact-form" id="contact-form">
-                    <div class="form-field">
-                        <label for="name">Name</label>
-                        <input type="text" id="name" name="name" placeholder="John Doe">
-                    </div>
-                    <div class="form-field">
-                        <label for="email-addr">Email address</label>
-                        <input type="email" id="email-addr" name="email-addr" pattern="[a-zA-Z0-9-_\.]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*" placeholder="name@domain.com">
-                    </div>
-                    <div class="form-field">
-                        <label for="message">Message</label>
-                        <textarea id="message" name="message" rows="7" cols="25" placeholder="Enter a message"></textarea>
-                    </div>
-                    <div id="form-errors" class="hide"></div>
-                    <div class="form-field">
-                        <button type="submit" id="submit" class="submit-button">Submit</button>
-                    </div>              
-                </form>
-            </section>
+        <section class="form-wrapper">
+            <h2>Contact Us</h2>
+            <form name="contact-form" id="contact-form">
+                <div class="form-field">
+                    <label for="name">Name</label>
+                    <input type="text" id="name" name="name" placeholder="John Doe">
+                </div>
+                <div class="form-field">
+                    <label for="email-addr">Email address</label>
+                    <input type="email" id="email-addr" name="email-addr" pattern="[a-zA-Z0-9-_\.]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*" placeholder="name@domain.com">
+                </div>
+                <div class="form-field">
+                    <label for="message">Message</label>
+                    <textarea id="message" name="message" rows="7" cols="25" placeholder="Enter a message"></textarea>
+                </div>
+                <div id="form-errors" class="hide"></div>
+                <div class="form-field">
+                    <button type="submit" id="submit" class="submit-button">Submit</button>
+                </div>              
+            </form>
         </section>
     </main>
 

--- a/contact.html
+++ b/contact.html
@@ -20,8 +20,8 @@
                 <h2>Contact Us</h2>
                 <form name="contact-form" id="contact-form">
                     <div class="form-field">
-                        <label for="full-name">Full Name</label>
-                        <input type="text" id="full-name" name="full-name" placeholder="John Doe">
+                        <label for="name">Name</label>
+                        <input type="text" id="name" name="name" placeholder="John Doe">
                     </div>
                     <div class="form-field">
                         <label for="email-addr">Email address</label>

--- a/css/style.css
+++ b/css/style.css
@@ -148,10 +148,6 @@ form div {
   margin-bottom: 1em;
 }
 
-.shadow-spacing {
-  padding: 2em;
-}
-
 .form-wrapper {
   background: #f9f1f8;
   padding: 2em 1em;
@@ -311,8 +307,7 @@ input, textarea {
 .tip-of-the-day {
   background-color: #f9f1f8;
   width: 90%;
-  padding: 1.5em 2em;
-  margin: 2em auto;
+  margin: auto;
   box-shadow: 10px 10px 5px #b25288;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -201,12 +201,6 @@ form textarea {
   transform: translateY(-1px);
 }
 
-.gallery-section h2 {
-  text-align: center;
-  color: #ce639e;
-  margin-bottom: 1.5em;
-}
-
 .gallery-item {
   border: 1px solid #e0d4dd;
   border-radius: 8px;
@@ -227,25 +221,6 @@ form textarea {
   font-size: 1.1em;
   color: #333;
 }
-
-.caption {
-  font-size: 0.9em;
-  color: #666;
-  margin-bottom: 0.5em;
-}
-
-.gallery-section {
-  padding: 2em 1em;
-  background: #ffffff;
-  max-width: 1000px;
-  margin: 2em auto;
-}
-
-/* .recipe-gallery {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1.5em;
-} */
 
 .gallery {
   display: grid;
@@ -289,15 +264,10 @@ form textarea {
   color: #333;
 }
 
-.form-plan {
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  form.planner-form {
-    max-width: none;   
-    width: 100%;
-  }
+form.planner-form {
+  max-width: none;   
+  width: 100%;
+}
 
 input, textarea {
   width: 100%;
@@ -311,23 +281,6 @@ input, textarea {
   padding: 2rem 1rem;
   max-width: 100%;
   margin: 0 auto;
-}
-
-.day {
-  background: #fff;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  padding: 1rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-
-.day h4 {
-  margin: 0 0 0.75rem;
-  font-size: 1.1rem;
-}
-
-.day input[type="text"] {
-  margin-bottom: 0.5rem;
 }
 
 .controls {

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,17 +1,17 @@
 function checkForm() {
-   const fullName = document.getElementById("full-name");
+   const name = document.getElementById("name");
    const email = document.getElementById("email-addr");
    const message = document.getElementById("message");
    const formErrors = document.getElementById("form-errors");
 
    formErrors.classList.remove("hide");
-   [fullName, email, message].forEach(input => input.classList.remove("error"));
+   [name, email, message].forEach(input => input.classList.remove("error"));
 
    let errors = [];
 
-   if (!fullName.value.match(/^[A-Za-z]+\s+[A-Za-z]+$/)) {
-      errors.push("Please enter both first and last name.");
-      fullName.classList.add("error");
+   if (name.value.trim().length < 1) {
+      errors.push("Please enter your name.");
+      name.classList.add("error");
    }
 
    if (!email.value.match(/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,5}$/)) {

--- a/tips.html
+++ b/tips.html
@@ -13,21 +13,19 @@
     <header></header>
     <main>
         <h1 class="centered-heading">Tips</h1>
-        <section class="shadow-spacing">
-            <section class="tip-of-the-day">
-                <h3 class="centered-heading" tabindex="1">Tip of the Day</h3>
-                <div class="tip-of-the-day-content">
-                    <blockquote>
-                        <q id="tip-of-the-day-quote" tabindex="2"><i>Add salt to your cutting board when mincing garlic</i></q>
-                        <p id="tip-of-the-day-author">- Gordan Ramsay</p>
-                        <p id="tip-of-the-day-details" tabindex="3">Since salt is abrasive, by adding salt to your cutting board before mincing garlic,
-                        it allows you to get a finer chop on the garlic. Additionally, salt will keep the garlic
-                        from sticking to your knife. Avoid buying a garlic press and try this tip instead!</p>
-                    </blockquote>
-                    <img id="tip-of-the-day-img" src="images/mincing-garlic.jpg" alt="mincing garlic on a cutting board">
-                </div>
-                <p id="double-click-message"><b>Double click anywhere in this box for a new quote!</b></p>
-            </section>
+        <section class="tip-of-the-day">
+            <h3 class="centered-heading" tabindex="1">Tip of the Day</h3>
+            <div class="tip-of-the-day-content">
+                <blockquote>
+                    <q id="tip-of-the-day-quote" tabindex="2"><i>Add salt to your cutting board when mincing garlic</i></q>
+                    <p id="tip-of-the-day-author">- Gordan Ramsay</p>
+                    <p id="tip-of-the-day-details" tabindex="3">Since salt is abrasive, by adding salt to your cutting board before mincing garlic,
+                    it allows you to get a finer chop on the garlic. Additionally, salt will keep the garlic
+                    from sticking to your knife. Avoid buying a garlic press and try this tip instead!</p>
+                </blockquote>
+                <img id="tip-of-the-day-img" src="images/mincing-garlic.jpg" alt="mincing garlic on a cutting board">
+            </div>
+            <p id="double-click-message"><b>Double click anywhere in this box for a new quote!</b></p>
         </section>
         <section class="gallery">
             <div class="recipe-card">

--- a/upload.html
+++ b/upload.html
@@ -14,48 +14,46 @@
   <header></header>
   
   <main>
-    <section class="shadow-spacing">
-      <section class="form-wrapper">
-        <h2>Share Your Recipe</h2>
-        <form action="#" method="post" enctype="multipart/form-data">
-          <div class="form-field">
-            <label for="user-email">Email</label>
-            <input type="email" id="user-email" name="user-email" placeholder="e.g., alex@example.com">
-          </div>
-          <div class="form-field">
-            <label for="user-name">Your Name</label>
-            <input type="text" id="user-name" name="user-name" placeholder="e.g., Alex">
-          </div>
-          <div class="form-field">
-            <label for="recipe-title">Recipe Title</label>
-            <input type="text" id="recipe-title" name="recipe-title" placeholder="e.g., Easy Pancakes">
-          </div>
-          <div class="form-field">
-            <label for="estimated-time">Estimated Time</label>
-            <input type="text" id="estimated-time" name="estimated-time" placeholder="e.g., 30 mins or 1 hour">
-          </div>
-          <div class="form-field">
-            <label for="estimated-cost">Estimated Cost</label>
-            <input type="text" id="estimated-cost" name="estimated-cost" placeholder="e.g., $10.00">
-          </div>
-          <div class="form-field">
-            <label for="recipe-image">Recipe Image</label>
-            <input type="file" id="recipe-image" name="recipe-image" accept="image/*">
-          </div>
-          <div class="form-field">
-            <label for="ingredients">Ingredients</label>
-            <textarea id="ingredients" name="ingredients" rows="4" placeholder="Ingredients (one per line)"></textarea>
-          </div>
-          <div class="form-field">
-            <label for="instructions">Instructions</label>
-            <textarea id="instructions" name="instructions" rows="5" placeholder="Step-by-step instructions"></textarea>
-          </div>
-          <div id="form-errors" class="hide"></div>
-          <div class="form-field">
-            <button type="submit" class="submit-button">Upload Recipe</button>
-          </div>
-        </form>
-      </section>
+    <section class="form-wrapper">
+      <h2>Share Your Recipe</h2>
+      <form action="#" method="post" enctype="multipart/form-data">
+        <div class="form-field">
+          <label for="user-email">Email</label>
+          <input type="email" id="user-email" name="user-email" placeholder="e.g., alex@example.com">
+        </div>
+        <div class="form-field">
+          <label for="user-name">Your Name</label>
+          <input type="text" id="user-name" name="user-name" placeholder="e.g., Alex">
+        </div>
+        <div class="form-field">
+          <label for="recipe-title">Recipe Title</label>
+          <input type="text" id="recipe-title" name="recipe-title" placeholder="e.g., Easy Pancakes">
+        </div>
+        <div class="form-field">
+          <label for="estimated-time">Estimated Time</label>
+          <input type="text" id="estimated-time" name="estimated-time" placeholder="e.g., 30 mins or 1 hour">
+        </div>
+        <div class="form-field">
+          <label for="estimated-cost">Estimated Cost</label>
+          <input type="text" id="estimated-cost" name="estimated-cost" placeholder="e.g., $10.00">
+        </div>
+        <div class="form-field">
+          <label for="recipe-image">Recipe Image</label>
+          <input type="file" id="recipe-image" name="recipe-image" accept="image/*">
+        </div>
+        <div class="form-field">
+          <label for="ingredients">Ingredients</label>
+          <textarea id="ingredients" name="ingredients" rows="4" placeholder="Ingredients (one per line)"></textarea>
+        </div>
+        <div class="form-field">
+          <label for="instructions">Instructions</label>
+          <textarea id="instructions" name="instructions" rows="5" placeholder="Step-by-step instructions"></textarea>
+        </div>
+        <div id="form-errors" class="hide"></div>
+        <div class="form-field">
+          <button type="submit" class="submit-button">Upload Recipe</button>
+        </div>
+      </form>
     </section>
   </main>
   


### PR DESCRIPTION
## What changes were made:
- Changed the `full-name` field to `name` and the form validation - based on the feedback we received during our presentation, people don't always have two names as their full name
- Removed the styling for unused HTML classes 
- Removed `.shadow-spacing` because it was adding unnecessary padding between the Tip of the Day and the title

**Before:**
<img width="3813" height="1841" alt="image" src="https://github.com/user-attachments/assets/dff05a16-1fa1-42e9-8172-3975d688febb" />

**After:**
<img width="3819" height="1455" alt="image" src="https://github.com/user-attachments/assets/27902f90-2f84-44fa-98aa-eb320e8cf59f" />
